### PR TITLE
feat(app): a few syntax fixes and small refactor

### DIFF
--- a/src/classes/handlers/YoutubeEvent.ts
+++ b/src/classes/handlers/YoutubeEvent.ts
@@ -1,5 +1,5 @@
 import { BaseEventHandler, ForgeClient } from '@tryforge/forgescript'
-import { ForgeNotifications } from '@structures/ForgeNotifications'
+import { ForgeNotifications } from '../structures/ForgeNotifications'
 
 type EventNames = 
    | 'videoUpload'
@@ -9,8 +9,8 @@ type EventNames =
 export class YoutubeEvent<T extends INotificationsEvents = INotificationsEvents> extends BaseEventHandler<any, T> {
      register(client: ForgeClient): void {
          const forgeNotifs = client.getExtension(ForgeNotifications, true);
-         if (forgeNotifs.event path) {
-             forgeNotifs.event path.on(this.name as any, (...args: any[]) => {
+         if (forgeNotifs.event.path) {
+             forgeNotifs.event.path.on(this.name as any, (...args: any[]) => {
                  this.listener.apply(client, args);
              });
          } else { 

--- a/src/classes/managers/CommandManager.ts
+++ b/src/classes/managers/CommandManager.ts
@@ -1,9 +1,13 @@
 import { BaseCommandManager } from '@tryforge/forgescript'
-import type { Events } from 'youtubei'
+//import type { Events } from 'youtubei'
 
 
 export const handlerName = "ForgeNotifications"
 
-export class YoutubeManager extends BaseCommandManager<keyof Events> {
+// commented out this verion to get tests running, no `Events` in 'youtubei'
+// export class YoutubeManager extends BaseCommandManager<keyof Events> {
+//      handlerName = 'YTCommands'
+// }
+export class YoutubeManager extends BaseCommandManager<any> {
      handlerName = 'YTCommands'
 }

--- a/src/classes/structures/ForgeNotifications.ts
+++ b/src/classes/structures/ForgeNotifications.ts
@@ -1,30 +1,32 @@
 import { EventManager, ForgeClient, ForgeExtension, FunctionManager } from '@tryforge/forgescript'
-import { DataBase } from '@tryforge/forge.db'
-import { YoutubeManager as CommandManager } from '@managers/CommandManager'
-import Youtube from 'youtubei'
+//import { ForgeDB } from '@tryforge/forge.db'
+import { YoutubeManager as CommandManager } from '../managers/CommandManager'
+//import Youtube from 'youtubei'
 import { join } from 'path'
 
 export interface YtConfig {
-  // Horror
+  // sample property to demonstrate passing values around
+  hello: string
 }
 
 export class ForgeNotifications extends ForgeExtension {
     name = 'forge.notifications'
     description = ''
     version = '1.0.0'
+    commands!: any
 
-     #kc: CommandManager
-
-     constructor(public options: YtConfig) {
-        super()
+    constructor(public options: YtConfig) {
+      super()
+      // log the option's hello property to the console
+      console.log(options.hello)
     }
 
-    this.#kc = new CommandManager(client);
-
-    public init() {
-     EventManager.load('youtubeEvents', join(__dirname, '../../events'));
-     this.load(join(__dirname, '../../natives'));
+    public init(client: ForgeClient): void {
+      this.commands = new CommandManager(client);
+      EventManager.load('youtubeEvents', join(__dirname, '../../events'));
+      this.load(join(__dirname, '../../natives'));
     }
 }
 
-
+// this would log 'hello world!' to the console
+let notif = new ForgeNotifications({hello: 'hello world!'})

--- a/src/functions/test.ts
+++ b/src/functions/test.ts
@@ -1,5 +1,5 @@
-import { MessageType } from "discord.js"
-import { Arg, NativeFunction } from @tryforge/forgescript"
+import { MessageType } from "discord.js";
+import { Arg, NativeFunction } from "@tryforge/forgescript";
 
 export default new NativeFunction({
     name: "$test",
@@ -10,3 +10,4 @@ export default new NativeFunction({
     async execute(ctx, args) {
         return this.success("Hi"!)
     },
+})


### PR DESCRIPTION
- youtubeEvents had some syntax errors that were corrected, these are temporary and will change as the extension changes. 
- CommandManager was modified for demonstration purposes. 
- test.ts had a few syntax issues that were fixed. 
- i modified the ytconfig interface to include a sample property to demonstrate passing values around.
- i also refactored the forgeNotifications class to use a simpler init function that is modeled after the one in forgedb. 
- in the constructor i added a little test log that logs the hello message that is instantiated at the bottom of the file
- i also modified the command manager property and assignment to be a little easier to understand and is modeled after forgedb, i assume this will need to be changed but it works for demonstration purposes.

i used `npx ts-node --files src/classes/structures/ForgeNotifications.ts` to run the specific typescript file, it is supposed to log 'hello world!'